### PR TITLE
Add support for recently added SSH key option in kops

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ module "application" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| product_domain_name | Name of product domain (e.g. maps) | string | - | yes |
-| environment_type | Type of environment (e.g. test, int, e2e, prod) | string | - | yes |
-| vpc_id | ID of existing VPC where cluster will be deployed (if not specified new VPC will be created | string | - | yes |
-| new_vpc_cidr | CIDR range for VPC. | string | `` | no |
-| new_vpc_private_subnets | (Optional) A list of private subnets expressed in CIDR notation. This list size must match the list size of availability zones. | list | `<list>` | no |
-| new_vpc_public_subnets | (Optional) A list of public subnets expressed in CIDR notation. This list size must match the list size of availability zones. | list | `<list>` | no |
-| new_vpc_elastic_ips | (Optional) A list of existing elastic ip addresses to assign to the VPC | list | `<list>` | no |
-| region | AWS region | string | - | yes |
-| azs | Availability Zones for the cluster (1 master per AZ will be deployed) | list | - | yes |
-| k8s_private_subnets | List of private subnets (matching AZs) where to deploy the cluster (required if existing VPC is used) | list | - | yes |
-| k8s_node_count | Number of worker nodes in Kubernetes cluster | string | `1` | no |
-| k8s_master_instance_type | Instance type (size) for master nodes | string | `m4.large` | no |
-| k8s_node_instance_type | Instance type (size) for worker nodes | string | `m4.large` | no |
-| iam_cross_account_role_arn | Cross-account role to assume before deploying the cluster | string | - | yes |
-| k8s_masters_iam_policies_arns | List of existing IAM policies that will be attached to instance profile for master nodes (EC2 instances) | list | - | yes |
-| k8s_nodes_iam_policies_arns | List of existing IAM policies that will be attached to instance profile for worker nodes (EC2 instances) | list | - | yes |
-
+| product\_domain\_name | Name of product domain (e.g. maps) | string | n/a | yes |
+| environment\_type | Type of environment (e.g. test, int, e2e, prod) | string | n/a | yes |
+| vpc\_id | ID of existing VPC where cluster will be deployed (if not specified new VPC will be created | string | n/a | yes |
+| new\_vpc\_cidr | CIDR range for VPC. | string | `""` | no |
+| new\_vpc\_private\_subnets | (Optional) A list of private subnets expressed in CIDR notation. This list size must match the list size of availability zones. | list | `<list>` | no |
+| new\_vpc\_public\_subnets | (Optional) A list of public subnets expressed in CIDR notation. This list size must match the list size of availability zones. | list | `<list>` | no |
+| new\_vpc\_elastic\_ips | (Optional) A list of existing elastic ip addresses to assign to the VPC | list | `<list>` | no |
+| region | AWS region | string | n/a | yes |
+| azs | Availability Zones for the cluster (1 master per AZ will be deployed) | list | n/a | yes |
+| k8s\_private\_subnets | List of private subnets (matching AZs) where to deploy the cluster (required if existing VPC is used) | list | n/a | yes |
+| k8s\_node\_count | Number of worker nodes in Kubernetes cluster | string | `"1"` | no |
+| k8s\_master\_instance\_type | Instance type (size) for master nodes | string | `"m4.large"` | no |
+| k8s\_node\_instance\_type | Instance type (size) for worker nodes | string | `"m4.large"` | no |
+| iam\_cross\_account\_role\_arn | Cross-account role to assume before deploying the cluster | string | n/a | yes |
+| k8s\_masters\_iam\_policies\_arns | List of existing IAM policies that will be attached to instance profile for master nodes (EC2 instances) | list | n/a | yes |
+| k8s\_nodes\_iam\_policies\_arns | List of existing IAM policies that will be attached to instance profile for worker nodes (EC2 instances) | list | n/a | yes |
+| k8s\_aws\_ssh\_keypair\_name | Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified) | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,7 @@ module "kubernetes_cluster_application" {
   node_count           = "${var.k8s_node_count}"
   master_instance_type = "${var.k8s_master_instance_type}"
   node_instance_type   = "${var.k8s_node_instance_type}"
+  aws_ssh_keypair_name = "${var.k8s_aws_ssh_keypair_name}"
 
   masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"
   nodes_iam_policies_arns   = "${var.k8s_nodes_iam_policies_arns}"

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,11 @@ variable "k8s_nodes_iam_policies_arns" {
   type        = "list"
 }
 
+variable "k8s_aws_ssh_keypair_name" {
+  description = "Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified)"
+  default     = ""
+}
+
 #variable "advanced_account_trusted_roles" {
 #  type = "list"
 #  default = []


### PR DESCRIPTION
This allows to specify an SSH key that already exists on application account to be used by kops when launching cluster instances.